### PR TITLE
added basic readme, updated deprecated call, added mac shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+### How to build
+
+Built tool is ant.

--- a/src/chrome_extension/background.js
+++ b/src/chrome_extension/background.js
@@ -124,7 +124,7 @@ function convertSelectedEditableInTab(tab) {
 
 function ConvertTurkishChars() {
   // Get the current tab:
-  chrome.tabs.getSelected(null, convertSelectedEditableInTab);
+  chrome.tabs.query({active: true}, convertSelectedEditableInTab);
 }
 
 function showNotification(title, text, timeout) {

--- a/src/chrome_extension/manifest.json
+++ b/src/chrome_extension/manifest.json
@@ -27,7 +27,8 @@
   "commands": {
     "toggle_deasciify": {
       "suggested_key": {
-        "default": "Alt+T"
+        "default": "Alt+T",
+        "default": "MacCtrl+Alt+T"
       },
       "description": "Toggle deasciify"
     }


### PR DESCRIPTION
- README file Closes #8
- Fixing deprecated call makes auto converting works with latest Firefox
- MacOS specific shortcut to handle some keyboard layouts which make Alt+<key> combinations to place different symbols