### PR TITLE
Add Keyboard Shortcuts for Deasciify Features in Firefox

### DIFF
--- a/src/firefox_extension/background.js
+++ b/src/firefox_extension/background.js
@@ -179,7 +179,13 @@ Deasciifier.onPatternListLoaded = function(patternListV2) {
 }
 
 browser.commands.onCommand.addListener(function (command) {
-  if (command === "DEASCIIFY_SHORTCUT") {
+  if (command === "DEASCIIFY_SELECTED_TOGGLE") {
     ConvertTurkishChars();
+  }
+
+  if (command === "AUTO_DEASCIIFY_TOGGLE") {
+    browser.tabs.executeScript({ file: "execute.js" }, function () {
+      browser.tabs.executeScript({ code: "toggleAutoDeasciify();" });
+    });
   }
 });

--- a/src/firefox_extension/background.js
+++ b/src/firefox_extension/background.js
@@ -177,3 +177,9 @@ chrome.contextMenus.create({
 Deasciifier.onPatternListLoaded = function(patternListV2) {
   Deasciifier.init(patternListV2);
 }
+
+browser.commands.onCommand.addListener(function (command) {
+  if (command === "DEASCIIFY_SHORTCUT") {
+    ConvertTurkishChars();
+  }
+});

--- a/src/firefox_extension/manifest.json
+++ b/src/firefox_extension/manifest.json
@@ -37,12 +37,19 @@
   },
 
   "commands": {
-    "DEASCIIFY_SHORTCUT": {
+    "DEASCIIFY_SELECTED_TOGGLE": {
       "suggested_key": {
         "default": "Alt+Shift+D",
         "mac": "Command+Alt+D"
       },
       "description": "Deasciify the selected text"
+    },
+    "AUTO_DEASCIIFY_TOGGLE": {
+      "suggested_key": {
+        "default": "Alt+Shift+A",
+        "mac": "Command+Alt+A"
+      },
+      "description": "Toggle auto-deasciify"
     }
   }
 }

--- a/src/firefox_extension/manifest.json
+++ b/src/firefox_extension/manifest.json
@@ -34,5 +34,15 @@
       "id": "firefox@deasciifier.com",
       "strict_min_version": "55.0"
     }
+  },
+
+  "commands": {
+    "DEASCIIFY_SHORTCUT": {
+      "suggested_key": {
+        "default": "Alt+Shift+D",
+        "mac": "Command+Alt+D"
+      },
+      "description": "Deasciify the selected text"
+    }
   }
 }


### PR DESCRIPTION
Feature: Add keyboard shortcuts for Deasciify features in Firefox

This pull request adds keyboard shortcuts for two features in the Firefox extension:

1. Deasciify Selected Text
   - Shortcut: Alt+Shift+D (Command+Alt+D on Mac)
2. Toggle Auto-Deasciify
   - Shortcut: Alt+Shift+A (Command+Alt+A on Mac)

These shortcuts allow users to quickly and easily access the extension's core functionalities without having to interact with the context menu or toolbar button.

Changes made:

1.  Added listeners for the new shortcuts in `background.js`:

````js
browser.commands.onCommand.addListener(function (command) {
  if (command === "DEASCIIFY_SELECTED_TOGGLE") {
  ConvertTurkishChars();
  }
 if (command === "AUTO_DEASCIIFY_TOGGLE") {
   browser.tabs.executeScript({ file: "execute.js" }, function () {
     browser.tabs.executeScript({ code: "toggleAutoDeasciify();" });
   });
 }
});
````
2. Added shortcut definitions in `manifest.js`:

```json
"commands": {
  "DEASCIIFY_SELECTED_TOGGLE": {
    "suggested_key": {
      "default": "Alt+Shift+D",
      "mac": "Command+Alt+D"
    },
  "description": "Deasciify the selected text"
  },
  "AUTO_DEASCIIFY_TOGGLE": {
    "suggested_key": {
      "default": "Alt+Shift+A",
      "mac": "Command+Alt+A"
    },
  "description": "Toggle auto-deasciify"
  }
}
```


Please review the changes and let me know if you have any feedback or if any further changes are required.

Thank you!
